### PR TITLE
perf: Use Hermes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,7 +80,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,7 @@ target 'Colorwaver' do
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods
-    :hermes_enabled => false
+    :hermes_enabled => true
   )
 
   pod 'UIImageColors'


### PR DESCRIPTION
Hermes is way faster than JSC and more up to date.

* Faster JSI calls because Hermes does not do as many C++ thread-lock-operations as JSC
  - Means: Faster Frame Processor <-> FP Plugin calls, so faster color palette detection
  - Means: Faster UI Worklet <-> C++ calls, so faster and more efficient animations
* Even faster app startup time because Hermes uses bytecode and is optimized for fast app startup
* Overall faster JS execution
* More up to date as Hermes will become the default JS Engine for React Native soon.

## Blockers

* [ ] iOS doesn't build for me after enabling Hermes (`<folly/folly-config.h> file not found` or `boost/operators.hpp file not found` C++ errors, rising from either RNReanimated or VisionCamera.)
* [ ] `ShareableValue::adapt` causes a SIGABRT crash on Hermes (`Tried to access a value backed by a different Runtime`)
* [x] Hermes' garbage collector (Hades GC) runs on a separate Thread, so the `jsi::HostObject` destructor is called on a Thread that might not have a JNI Environment attached. This crashes on Android after a few seconds of running the Frame Processor. (FIXED)